### PR TITLE
ops(prompts): enqueue P0009 (codex) & P0010 (claude) for PR #4

### DIFF
--- a/prompts/P0009-codex-finish-pr4-conflicts-and-ci.md
+++ b/prompts/P0009-codex-finish-pr4-conflicts-and-ci.md
@@ -1,0 +1,78 @@
+# → Prompt for **Codex**
+
+## `prompts/P0009-codex-finish-pr4-conflicts-and-ci.md`
+
+**Title:** Finish PR #4 (vendor Redocly CLI), resolve conflicts, and prove CI is green
+
+**Context**
+
+* Repo: `esl365/jobboard-spec-suite`
+* Open PR: **#4 – chore(ci): vendor redocly cli for offline preflight**
+* Head branch: `codex/run-pre-flight-and-log-issues-8cw2da`
+* Base branch: `main`
+* Recent changes: GAP-003 closed by vendored Redocly; GAP-004 logged (offline workspace w/o origin remote). New workflows:
+
+  * `.github/workflows/spec-preflight.yml`
+  * `.github/workflows/pr-conflict-notify.yml`
+  * `.github/workflows/prompt-watcher.yml`
+
+**Objectives**
+
+1. Rebase/merge `main` → `codex/run-pre-flight-and-log-issues-8cw2da` and **resolve conflicts** canonically.
+2. Ensure **CI passes** on the head branch: `spec-runner` and `spec-preflight` both green.
+3. Flip PR #4 to **Ready for review**, post evidence, and update the prompt queue (DONE).
+
+**Canonical conflict resolutions (apply exactly)**
+
+* `src/payments/adapters/mock.ts`
+
+  * HMAC digest must be **`base64`**, not hex.
+  * Compare via `crypto.timingSafeEqual`.
+* `src/routes/webhooks.payments.ts`
+
+  * **Use captured `request.rawBody`** only; **no** stringify fallback on the verifier path.
+  * Enforce ±300s timestamp tolerance.
+  * De-dupe **before** effects; single TX for state change + ledger append; replay → 200/no duplicate effects.
+* `src/payments/registry.ts`
+
+  * Keep **mock provider only** by default.
+* `src/infra/memory/payments.repos.ts`
+
+  * Keep current interface/transactions aligned with DB repo; no raw SQL in handlers.
+* `package.json` & `scripts/openapi-lint.mjs`
+
+  * Keep **vendored Redocly** preference (tools/redocly-cli/redocly), then global, then offline fallback.
+  * `npm run preflight` should run: openapi lint → drift check → summary line with **mismatch count**.
+
+**What to push**
+
+* Conflict-resolution commits on `codex/run-pre-flight-and-log-issues-8cw2da`.
+* No unrelated churn.
+
+**Evidence to post on PR #4 (top-level comments)**
+
+1. **Preflight tail (last ~20 lines)** showing lint pass + **`drift: 0`**.
+2. **Test tail (last ~20 lines)** –  all suites pass.
+3. **Drift report header** – first 10 lines of `reports/spec-openapi-ddl-drift.md` proving *mismatches = 0*.
+4. **Links** to the two latest workflow runs (spec-runner, spec-preflight) on the head branch.
+5. **Code pointers** (file:line) for:
+
+   * base64 signature + safe compare
+   * raw-body middleware path (no stringify)
+   * unique `(provider, event_uid)` constraint (schema + migration)
+   * de-dupe → TX → order update → ledger append
+   * acceptance tests mapping (replay/sig/timestamp/idempotency)
+
+**STOP rules (block and report in PR if any fail)**
+
+* OpenAPI↔DDL **drift > 0**
+* Any tests failing
+* Signature digest **not** base64 or non-constant-time compare
+* rawBody fallback present
+* De-dupe after side effects or missing single transaction
+
+**Completion**
+
+* Flip PR #4 to **Ready for review**.
+* Comment with all evidence above.
+* Append a `## DONE (YYYY-MM-DD)` section to `prompts/P0003-codex-vendor-redocly-cli.md` and this prompt (`P0009`) with links to runs/commits.

--- a/prompts/P0010-claude-review-pr4-and-queue.md
+++ b/prompts/P0010-claude-review-pr4-and-queue.md
@@ -1,0 +1,47 @@
+# → Prompt for **Claude Code**
+
+## `prompts/P0010-claude-review-pr4-and-queue.md`
+
+**Title:** 7-phase review & queue upkeep after Codex finishes PR #4
+
+**Pre-conditions**
+
+* PR #4 is in **Ready for review** state.
+* Evidence on PR shows: **spec-runner ✅**, **spec-preflight ✅**, **drift = 0**, tests passing.
+
+**Tasks (do now upon pre-conditions met)**
+
+1. **Apply 7-phase review** using repo templates:
+
+   * `docs/CODEX_PR_REVIEW_COMMENTS.md` and `docs/PR_REVIEW_PROTOCOL.md`.
+   * Post 3 deliverables on PR #4:
+
+     * Spec-Trace Coverage (all acceptance IDs)
+     * Preflight Gate (lint + drift + tests; explicitly note `drift = 0`)
+     * Exactly-Once Evidence (unique index, de-dupe before effects, single TX, replay test)
+2. **Verdict comment**
+
+   * If all green → **APPROVE** (GAP-003 closed; GAP-004 is documentation; no open blockers).
+   * If any STOP rule was tripped → **REQUEST CHANGES** and open a new `SPEC_GAP` entry.
+3. **Prompt queue hygiene**
+
+   * Update `prompts/P0002-claude-7phase-review-and-approval.md` with a `## DONE (YYYY-MM-DD)` including links to the three deliverables and the final verdict.
+   * If `prompt-watcher` is enabled, ensure `CLAUDE_INBOX_ISSUE_NUMBER` is set; if missing, add a note to `SPEC_GAPS.md` and a short follow-up prompt `P0011` to wire it.
+
+**Evidence to include in your comments**
+
+* Links to the two green workflow runs (spec-runner, spec-preflight).
+* Drift report header lines (showing mismatches = 0).
+* File:line anchors for signature base64+safe-compare, raw body use, unique index, TX boundaries, acceptance tests.
+
+**STOP rules**
+
+* Contract drift > 0, unapproved DDL, de-dupe after effects, missing single TX, hex signatures, non-constant-time compare.
+
+**Completion**
+
+* Post APPROVE/REQUEST CHANGES on PR #4.
+* Update the two prompt files with `## DONE` and links.
+* If APPROVE, suggest merge then close any residual GAP items.
+
+


### PR DESCRIPTION
## Summary
Add two prompt-queue items for the PR #4 flow (codex conflict+CI finish → claude 7-phase review).

## Prompts
- `prompts/P0009-codex-finish-pr4-conflicts-and-ci.md`
  - Resolve PR #4 conflicts (the 5 listed files)
  - Run `npm run preflight` + `npm test`
  - Confirm drift = 0 and post evidence tails
  - Mark DONE in the prompt with links
- `prompts/P0010-claude-review-pr4-and-queue.md`
  - Perform 7-phase review on PR #4
  - Post deliverables (Coverage / Preflight Gate / Exactly-Once)
  - Final verdict + SPEC_GAPS status
  - Mark DONE with links

## Automation
- `prompt-watcher.yml` will watch `prompts/` updates
- `spec-preflight.yml` runs the preflight/test gate
- `pr-conflict-notify.yml` comments if conflicts remain

## Links
- PR #4: chore(ci): vendor redocly cli for offline preflight
