### PR TITLE
fix(gemini): fix API model name and environment variables

### DIFF
--- a/.github/workflows/gemini-spec-manager.yml
+++ b/.github/workflows/gemini-spec-manager.yml
@@ -247,6 +247,11 @@ jobs:
         env:
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          ISSUE_TITLE: ${{ github.event.issue.title }}
+          ISSUE_BODY: ${{ github.event.issue.body }}
+          PR_NUMBER: ${{ github.event.issue.pull_request && github.event.pull_request.number || '' }}
+          PR_TITLE: ${{ github.event.issue.pull_request && github.event.pull_request.title || '' }}
         run: |
           if [ "${{ github.event.issue.pull_request }}" ]; then
             echo "Analyzing PR..."

--- a/scripts/gemini-analyze-drift.mjs
+++ b/scripts/gemini-analyze-drift.mjs
@@ -13,7 +13,9 @@
 import { readFile, writeFile } from 'fs/promises';
 import { existsSync } from 'fs';
 
-const GEMINI_API_URL = 'https://generativelanguage.googleapis.com/v1beta/models/gemini-pro:generateContent';
+// Use gemini-1.5-flash for fast, cost-effective analysis
+// Alternative: gemini-1.5-pro for more complex reasoning
+const GEMINI_API_URL = 'https://generativelanguage.googleapis.com/v1beta/models/gemini-1.5-flash:generateContent';
 
 /**
  * Gemini API 호출

--- a/scripts/gemini-analyze-issue.mjs
+++ b/scripts/gemini-analyze-issue.mjs
@@ -15,9 +15,11 @@
  * - ISSUE_BODY: Issue description
  */
 
-import { writeFile } from 'fs/promises';
+import { writeFile, mkdir } from 'fs/promises';
 
-const GEMINI_API_URL = 'https://generativelanguage.googleapis.com/v1beta/models/gemini-pro:generateContent';
+// Use gemini-1.5-flash for fast, cost-effective analysis
+// Alternative: gemini-1.5-pro for more complex reasoning
+const GEMINI_API_URL = 'https://generativelanguage.googleapis.com/v1beta/models/gemini-1.5-flash:generateContent';
 
 /**
  * Gemini API 호출
@@ -144,6 +146,9 @@ Format the response as structured Markdown.`;
  * 명세 파일 생성
  */
 async function generateSpecFiles(analysis, issueNumber) {
+  // spec-updates 디렉토리 생성
+  await mkdir('spec-updates', { recursive: true });
+
   // OpenAPI 추출
   const openapiMatch = analysis.match(/```yaml\n([\s\S]*?)\n```/);
   if (openapiMatch) {


### PR DESCRIPTION
Fix Gemini automation failures:

1. Update API model name
   - gemini-pro → gemini-1.5-flash (v1beta compatible)
   - gemini-pro is deprecated and not available in v1beta API
   - gemini-1.5-flash is faster and more cost-effective

2. Add environment variables to manual-analysis job
   - ISSUE_NUMBER: Issue number from event
   - ISSUE_TITLE: Issue title
   - ISSUE_BODY: Issue description
   - PR_NUMBER & PR_TITLE: For PR analysis
   - Fixes "Analyzing Issue #unknown: Unknown Issue" error

3. Add directory creation
   - Create spec-updates/ directory before writing files
   - Prevents ENOENT errors when generating specs

Changes:
- scripts/gemini-analyze-issue.mjs:
  - Import mkdir from fs/promises
  - Update GEMINI_API_URL to use gemini-1.5-flash
  - Add mkdir('spec-updates', {recursive: true}) in generateSpecFiles
- scripts/gemini-analyze-drift.mjs:
  - Update GEMINI_API_URL to use gemini-1.5-flash
- .github/workflows/gemini-spec-manager.yml:
  - Add ISSUE_NUMBER, ISSUE_TITLE, ISSUE_BODY env vars
  - Add PR_NUMBER, PR_TITLE env vars for PR analysis

Testing:
- Will retry with Issue #20 after merge
- Expected: Gemini successfully analyzes and generates specs

🤖 Generated with [Claude Code](https://claude.com/claude-code)