### PR TITLE
fix(gemini): change API from v1beta to v1

### DIFF
--- a/scripts/gemini-analyze-drift.mjs
+++ b/scripts/gemini-analyze-drift.mjs
@@ -13,9 +13,9 @@
 import { readFile, writeFile } from 'fs/promises';
 import { existsSync } from 'fs';
 
-// Use gemini-1.5-flash for fast, cost-effective analysis
-// Alternative: gemini-1.5-pro for more complex reasoning
-const GEMINI_API_URL = 'https://generativelanguage.googleapis.com/v1beta/models/gemini-1.5-flash:generateContent';
+// Use Gemini 1.5 Flash via v1 API (stable)
+// v1 API is more stable than v1beta
+const GEMINI_API_URL = 'https://generativelanguage.googleapis.com/v1/models/gemini-1.5-flash:generateContent';
 
 /**
  * Gemini API 호출

--- a/scripts/gemini-analyze-issue.mjs
+++ b/scripts/gemini-analyze-issue.mjs
@@ -17,9 +17,9 @@
 
 import { writeFile, mkdir } from 'fs/promises';
 
-// Use gemini-1.5-flash for fast, cost-effective analysis
-// Alternative: gemini-1.5-pro for more complex reasoning
-const GEMINI_API_URL = 'https://generativelanguage.googleapis.com/v1beta/models/gemini-1.5-flash:generateContent';
+// Use Gemini 1.5 Flash via v1 API (stable)
+// v1 API is more stable than v1beta
+const GEMINI_API_URL = 'https://generativelanguage.googleapis.com/v1/models/gemini-1.5-flash:generateContent';
 
 /**
  * Gemini API 호출


### PR DESCRIPTION
Use stable v1 API instead of v1beta:
- v1beta/models/gemini-1.5-flash: NOT FOUND
- v1/models/gemini-1.5-flash: ✅ WORKS

Changes:
- scripts/gemini-analyze-issue.mjs: v1beta → v1
- scripts/gemini-analyze-drift.mjs: v1beta → v1

v1 API is more stable and widely supported.

🤖 Generated with [Claude Code](https://claude.com/claude-code)