### PR TITLE
fix(gemini): add -latest suffix to model name

### DIFF
--- a/scripts/gemini-analyze-drift.mjs
+++ b/scripts/gemini-analyze-drift.mjs
@@ -13,9 +13,9 @@
 import { readFile, writeFile } from 'fs/promises';
 import { existsSync } from 'fs';
 
-// Use Gemini 1.5 Flash via v1 API (stable)
-// v1 API is more stable than v1beta
-const GEMINI_API_URL = 'https://generativelanguage.googleapis.com/v1/models/gemini-1.5-flash:generateContent';
+// Use Gemini 1.5 Flash Latest via v1 API
+// -latest suffix is required for stable v1 API
+const GEMINI_API_URL = 'https://generativelanguage.googleapis.com/v1/models/gemini-1.5-flash-latest:generateContent';
 
 /**
  * Gemini API 호출

--- a/scripts/gemini-analyze-issue.mjs
+++ b/scripts/gemini-analyze-issue.mjs
@@ -17,9 +17,9 @@
 
 import { writeFile, mkdir } from 'fs/promises';
 
-// Use Gemini 1.5 Flash via v1 API (stable)
-// v1 API is more stable than v1beta
-const GEMINI_API_URL = 'https://generativelanguage.googleapis.com/v1/models/gemini-1.5-flash:generateContent';
+// Use Gemini 1.5 Flash Latest via v1 API
+// -latest suffix is required for stable v1 API
+const GEMINI_API_URL = 'https://generativelanguage.googleapis.com/v1/models/gemini-1.5-flash-latest:generateContent';
 
 /**
  * Gemini API 호출


### PR DESCRIPTION
Use gemini-1.5-flash-latest instead of gemini-1.5-flash:
- gemini-1.5-flash: NOT FOUND in v1 API
- gemini-1.5-flash-latest: ✅ REQUIRED for v1 API

The -latest suffix is mandatory for stable v1 API.

Changes:
- scripts/gemini-analyze-issue.mjs: gemini-1.5-flash → gemini-1.5-flash-latest
- scripts/gemini-analyze-drift.mjs: gemini-1.5-flash → gemini-1.5-flash-latest

🤖 Generated with [Claude Code](https://claude.com/claude-code)