### PR TITLE
fix: add helmet dependency and implement refresh token in auth

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "class-transformer": "^0.5.1",
         "class-validator": "^0.14.0",
         "handlebars": "^4.7.8",
+        "helmet": "7.2.0",
         "ioredis": "^5.3.2",
         "multer": "^2.0.2",
         "nodemailer": "^7.0.10",
@@ -8932,6 +8933,15 @@
       "optional": true,
       "bin": {
         "he": "bin/he"
+      }
+    },
+    "node_modules/helmet": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/helmet/-/helmet-7.2.0.tgz",
+      "integrity": "sha512-ZRiwvN089JfMXokizgqEPXsl2Guk094yExfoDXR0cBYWxtBbaSww/w+vT4WEJsBW2iTUi1GgZ6swmoug3Oy4Xw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.0.0"
       }
     },
     "node_modules/html-escaper": {

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "class-transformer": "^0.5.1",
     "class-validator": "^0.14.0",
     "handlebars": "^4.7.8",
+    "helmet": "7.2.0",
     "ioredis": "^5.3.2",
     "multer": "^2.0.2",
     "nodemailer": "^7.0.10",

--- a/src/modules/auth/auth.service.spec.ts
+++ b/src/modules/auth/auth.service.spec.ts
@@ -93,6 +93,7 @@ describe('AuthService', () => {
       expect(result).toEqual({
         accessToken: 'mock-jwt-token',
         tokenType: 'bearer',
+        refreshToken: 'mock-jwt-token',
         expiresIn: 86400,
         user: {
           id: 1,
@@ -165,6 +166,7 @@ describe('AuthService', () => {
       expect(result).toEqual({
         accessToken: 'mock-jwt-token',
         tokenType: 'bearer',
+        refreshToken: 'mock-jwt-token',
         expiresIn: 86400,
         user: {
           id: 1,

--- a/src/modules/auth/auth.service.ts
+++ b/src/modules/auth/auth.service.ts
@@ -76,6 +76,7 @@ export class AuthService {
     };
 
     const accessToken = this.jwtService.sign(payload);
+    const refreshToken = this.jwtService.sign(payload, { expiresIn: '7d' });
 
     // Send welcome email (non-blocking)
     const username = email.split('@')[0];
@@ -86,6 +87,7 @@ export class AuthService {
     return {
       accessToken,
       tokenType: 'bearer',
+      refreshToken,
       expiresIn: 86400, // 24 hours
       user: {
         id: Number(user.id),
@@ -138,10 +140,12 @@ export class AuthService {
     };
 
     const accessToken = this.jwtService.sign(payload);
+    const refreshToken = this.jwtService.sign(payload, { expiresIn: '7d' });
 
     return {
       accessToken,
       tokenType: 'bearer',
+      refreshToken,
       expiresIn: 86400, // 24 hours
       user: {
         id: Number(user.id),
@@ -178,10 +182,12 @@ export class AuthService {
     };
 
     const accessToken = this.jwtService.sign(payload);
+    const refreshToken = this.jwtService.sign(payload, { expiresIn: '7d' });
 
     return {
       accessToken,
       tokenType: 'bearer',
+      refreshToken,
       expiresIn: 86400, // 24 hours
       user: {
         id: Number(user.id),

--- a/src/modules/auth/dto/auth-response.dto.ts
+++ b/src/modules/auth/dto/auth-response.dto.ts
@@ -14,6 +14,12 @@ export class AuthResponseDto {
   tokenType: string;
 
   @ApiProperty({
+    example: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...',
+    description: 'JWT refresh token',
+  })
+  refreshToken: string;
+
+  @ApiProperty({
     example: 86400,
     description: 'Token expiration time in seconds',
   })


### PR DESCRIPTION
Fixed CI/CD errors:

1. **helmet dependency issue**:
   - Added helmet@7.2.0 to package.json dependencies
   - Updated package-lock.json with npm install

2. **refreshToken implementation**:
   - Added refreshToken field to AuthResponseDto (auth-response.dto.ts)
   - Implemented refreshToken generation in AuthService:
     - register() method: generates refresh token with 7-day expiration
     - login() method: generates refresh token with 7-day expiration - refresh() method: generates new refresh token with 7-day expiration
   - Refresh tokens use the same JWT secret but with longer expiration (7 days vs 24 hours for access tokens)

These changes resolve the following CI errors:
- npm ci failing due to missing helmet@7.2.0 in lock file
- TypeScript compilation error: Property 'refreshToken' is missing in type AuthResponseDto

🤖 Generated with [Claude Code](https://claude.com/claude-code)